### PR TITLE
Add a "discrete mode" for t-digest sketching and sampling

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ organization := "org.isarnproject"
 
 bintrayOrganization := Some("isarn")
 
-version := "0.0.3.rc1"
+version := "0.1.0.rc1"
 
 scalaVersion := "2.10.6"
 

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ organization := "org.isarnproject"
 
 bintrayOrganization := Some("isarn")
 
-version := "0.0.2"
+version := "0.0.3.rc1"
 
 scalaVersion := "2.10.6"
 

--- a/src/main/scala/org/isarnproject/sketches/TDigest.scala
+++ b/src/main/scala/org/isarnproject/sketches/TDigest.scala
@@ -74,7 +74,7 @@ case class TDigest(
       else {
         // too many clusters: attempt to compress it by re-clustering
         val ds = TDigest.shuffle(s.clusters.toVector)
-        ds.foldLeft(TDigest.empty(delta))((d, e) => d.update(e))
+        ds.foldLeft(TDigest.empty(delta, maxDiscrete))((d, e) => d.update(e))
       }
     }
   }
@@ -213,12 +213,12 @@ object TDigest {
    */
   def sketch[N](
     data: TraversableOnce[N],
-    delta: Double = deltaDefault)(implicit num: Numeric[N],
-    maxDiscrete: Int = 0): TDigest = {
+    delta: Double = deltaDefault,
+    maxDiscrete: Int = 0)(implicit num: Numeric[N]): TDigest = {
     require(delta > 0.0, s"delta was not > 0")
     require(maxDiscrete >= 0, s"maxDiscrete was not >= 0")
     val td = data.foldLeft(empty(delta, maxDiscrete))((c, e) => c + ((e, 1)))
-    TDigest.shuffle(td.clusters.toVector).foldLeft(empty(delta))((c, e) => c + e)
+    TDigest.shuffle(td.clusters.toVector).foldLeft(empty(delta, maxDiscrete))((c, e) => c + e)
   }
 
   /**

--- a/src/main/scala/org/isarnproject/sketches/TDigest.scala
+++ b/src/main/scala/org/isarnproject/sketches/TDigest.scala
@@ -16,6 +16,8 @@ limitations under the License.
 
 package org.isarnproject.sketches
 
+import scala.util.Random
+
 import tdmap.TDigestMap
 
 /**
@@ -166,6 +168,51 @@ case class TDigest(
    * @return the value x such that cdf(x) = q
    */
   def cdfInverse[N](q: N)(implicit num: Numeric[N]): Double = clusters.cdfInverse(q)
+
+  /**
+   * Compute a cumulative probability (CDF) for a numeric value, from the estimated probability
+   * distribution represented by this t-digest sketch, assuming sketch is "discrete"
+   * (e.g. if number of clusters <= maxDiscrete setting)
+   * @param x a numeric value
+   * @return the cumulative probability that a random sample from the distribution is <= x
+   */
+  def cdfDiscrete[N](x: N)(implicit num: Numeric[N]): Double =
+    clusters.cdfDiscrete(x)
+
+  /**
+   * Compute the inverse cumulative probability (inverse-CDF) for a quantile value, from the
+   * estimated probability distribution represented by this t-digest sketch,
+   * assuming the sketch is "discrete" (e.g. if number of clusters <= maxDiscrete setting)
+   * @param q a quantile value.  The value of q is expected to be on interval [0, 1]
+   * @return the smallest value x such that q <= cdf(x)
+   */
+  def cdfDiscreteInverse[N](q: N)(implicit num: Numeric[N]): Double =
+    clusters.cdfDiscreteInverse(q)
+
+  /**
+   * Perform a random sampling from the distribution as sketched by this t-digest, in
+   * "probability density" mode.
+   * @return A random number sampled from the sketched distribution
+   * @note uses the inverse transform sampling method
+   */
+  def samplePDF: Double = clusters.cdfInverse(Random.nextDouble)
+
+  /**
+   * Perform a random sampling from the distribution as sketched by this t-digest, in
+   * "probability mass" (i.e. discrete) mode.
+   * @return A random number sampled from the sketched distribution
+   * @note uses the inverse transform sampling method
+   */
+  def samplePMF: Double = clusters.cdfDiscreteInverse(Random.nextDouble)
+
+  /**
+   * Perform a random sampling from the distribution as sketched by this t-digest,
+   * using "discrete" (PMF) mode if the number of clusters <= maxDiscrete setting,
+   * and "density" (PDF) mode otherwise.
+   * @return A random number sampled from the sketched distribution
+   * @note uses the inverse transform sampling method
+   */
+  def sample: Double = if (nclusters <= maxDiscrete) samplePMF else samplePDF
 }
 
 /** Factory functions for TDigest */

--- a/src/test/scala/org/isarnproject/sketches/TDigestTest.scala
+++ b/src/test/scala/org/isarnproject/sketches/TDigestTest.scala
@@ -116,9 +116,8 @@ class TDigestTest extends FlatSpec with Matchers {
     val kt = dataUniq.map(_.toDouble).toSet
     val td = TDigest.sketch(data, maxDiscrete = 50)
     val clust = td.clusters
-    val n = data.size.toDouble
     clust.keys.toSet should be (kt)
-    val D = clust.prefixSums().map(_ / n)
+    val D = clust.keys.map { x => td.cdfDiscrete(x) }
       .zip(dataUniq.map { k => gd.cumulativeProbability(k) })
       .map { case (p1, p2) => math.abs(p1 - p2) }
       .max
@@ -133,8 +132,7 @@ class TDigestTest extends FlatSpec with Matchers {
     val td = tdvec.reduce(_ ++ _)
     val clust = td.clusters
     clust.keys.map(_.toInt).map(_.toDouble) should beEqSeq(clust.keys)
-    val n = clust.prefixSum(clust.keyMax.get)
-    val D = clust.prefixSums().map(_ / n)
+    val D = clust.keys.map { x => td.cdfDiscrete(x) }
       .zip(clust.keys.map(_.toInt).map { k => gd.cumulativeProbability(k) })
       .map { case (p1, p2) => math.abs(p1 - p2) }
       .max


### PR DESCRIPTION
Adds a new parameter `maxDiscrete` (which defaults to zero).  As long as the number of unique values seen by the t-digest is <= this number, it will simply count the values instead of invoking the normal t-digest data merging logic.

Also added some new methods on `TDigest`
* `cdfDiscrete(x)`  compute CDF of x, assuming a discrete-mode t digest
* `cdfDiscreteInverse(q)`  compute inverse-CDF of q, assuming a discrete-mode t digest
* `samplePDF` random-sample from the distribution sketch, assuming density (PMF) mode
* `samplePMF` random-sample from the distribution sketch, assuming discrete (PMF) mode
* `sample` sample using PMF mode if number of clusters is <= `maxDiscrete`, PDF mode otherwise
